### PR TITLE
Added swift-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The idea is that we can share pre-compiled commands. Submit yours through pull-r
 - [json2csv](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/json2csv): http://github.com/buger/jsonparser/
 - [lzmadec](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/lzmadec.wasm), [lzmainfo](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/lzmainfo.wasm): https://git.tukaani.org/xz
 - [sqlite3](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/sqlite3.wasm): https://www.sqlite.org/index.html
+- [swift-format](https://github.com/kkebo/swift-format)
 - [zip](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/zip.wasm), [unzip](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/unzip.wasm), [zipcloak](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/zipcloak.wasm), [zipnote](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/zipnote.wasm), [zipsplit](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/zipsplit.wasm), [funzip](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/funzip.wasm), [unzipsfx](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/unzipsfx.wasm): http://infozip.sourceforge.net/UnZip.html
 
 

--- a/list
+++ b/list
@@ -50,6 +50,7 @@ seq
 split
 sqlite3
 strings
+swift-format
 texlive
 texlive-2025
 texlive_fonts

--- a/packages/swift-format
+++ b/packages/swift-format
@@ -6,7 +6,7 @@ packageversion=601.0.0
 
 # download command:
 curl -L https://github.com/kkebo/swift-format/releases/download/$packageversion-wasm32-wasi/swift-format.wasm -o ~/Documents/bin/"$packagename".wasm3 --create-dirs --silent
-chmod +x ~/Documents/bin/"$packagename"
+chmod +x ~/Documents/bin/"$packagename".wasm3
 
 # download uninstall information:
 curl -L https://raw.githubusercontent.com/holzschu/a-Shell-commands/master/uninstall/"$packagename" -o ~/Documents/.pkg/"$packagename" --create-dirs --silent

--- a/packages/swift-format
+++ b/packages/swift-format
@@ -1,0 +1,12 @@
+#!/bin/sh
+# install file for swift-format:
+
+packagename=${0##*/}
+packageversion=601.0.0
+
+# download command:
+curl -L https://github.com/kkebo/swift-format/releases/download/$packageversion-wasm32-wasi/swift-format.wasm -o ~/Documents/bin/"$packagename" --create-dirs --silent
+chmod +x ~/Documents/bin/"$packagename"
+
+# download uninstall information:
+curl -L https://raw.githubusercontent.com/holzschu/a-Shell-commands/master/uninstall/"$packagename" -o ~/Documents/.pkg/"$packagename" --create-dirs --silent

--- a/packages/swift-format
+++ b/packages/swift-format
@@ -5,7 +5,7 @@ packagename=${0##*/}
 packageversion=601.0.0
 
 # download command:
-curl -L https://github.com/kkebo/swift-format/releases/download/$packageversion-wasm32-wasi/swift-format.wasm -o ~/Documents/bin/"$packagename" --create-dirs --silent
+curl -L https://github.com/kkebo/swift-format/releases/download/$packageversion-wasm32-wasi/swift-format.wasm -o ~/Documents/bin/"$packagename".wasm3 --create-dirs --silent
 chmod +x ~/Documents/bin/"$packagename"
 
 # download uninstall information:

--- a/uninstall/swift-format
+++ b/uninstall/swift-format
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+packagename=${0##*/}
+
+# remove command
+rm ~/Documents/bin/"$packagename"

--- a/uninstall/swift-format
+++ b/uninstall/swift-format
@@ -3,4 +3,4 @@
 packagename=${0##*/}
 
 # remove command
-rm ~/Documents/bin/"$packagename"
+rm ~/Documents/bin/"$packagename".wasm3


### PR DESCRIPTION
## Motivation

swift-format is the official formatter and linter for Swift. It does not yet support compilation to Wasm, but the fork maintained by me can be compiled to Wasm. So it can run on a-Shell.

- The official repo: https://github.com/swiftlang/swift-format
- The fork with Wasm support: https://github.com/kkebo/swift-format ([diff](https://github.com/swiftlang/swift-format/compare/release/6.1...kkebo:swift-format:wasm32-wasi-release/6.1#files_bucket))

Personally, I have been using it on a-Shell for more than two years and I think it is stable enough, so I would like to add it to a-Shell-Commands to make it easier for other users to use it on a-Shell. Running it on a-Shell has advantages such as being able to format code on iPadOS for app projects created in [Swift Playground](https://apps.apple.com/app/id908519492/).

## Changes

I added scripts for swift-format so that users can install `swift-fromat` with `pkg install swift-format` and uninstall with `pkg uninstall swift-format`.[^1]

[^1]: Reference: https://bianshen00009.gitbook.io/a-guide-to-a-shell/lets-do-more-for-it/submit-new-packages

## Test

Installing:

```console
$ swift-format --version
swift-format: command not found
$ PKG_SERVER=https://raw.githubusercontent.com/kkebo/a-Shell-commands/swift-format/ pkg install swift-format
Downloading swift-format
Done
$ swift-format --version
601.0.0
```

Uninstalling (`.pkg/swift-format` is 404 because this PR is not yet merged, so I replaced it with the correct script manually):

```console
$ cat .pkg/swift-format
404: Not Found
$ cp ~Repositories/a-Shell-commands/uninstall/swift-format .pkg/swift-format
$ swift-format --version
601.0.0
$ pkg uninstall swift-format
Removing swift-format
Done
$ swift-format --version
swift-format: command not found
```

## Discussion

Ideally, I would prefer to use `wasm3` over `wasm` due to the noticeable difference in file reading speed, but due to https://github.com/holzschu/a-shell/issues/923, I have created a PR using `wasm` for now. If https://github.com/holzschu/a-shell/issues/923 is resolved or if https://github.com/holzschu/a-shell/issues/923 does not matter for users, I would be happy to use `wasm3`. What do you think?