### PR TITLE
Added ufetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The idea is that we can share pre-compiled commands. Submit yours through pull-r
 - [lzmadec](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/lzmadec.wasm), [lzmainfo](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/lzmainfo.wasm): https://git.tukaani.org/xz
 - [sqlite3](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/sqlite3.wasm): https://www.sqlite.org/index.html
 - [zip](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/zip.wasm), [unzip](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/unzip.wasm), [zipcloak](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/zipcloak.wasm), [zipnote](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/zipnote.wasm), [zipsplit](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/zipsplit.wasm), [funzip](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/funzip.wasm), [unzipsfx](https://github.com/holzschu/a-Shell-commands/releases/download/0.1/unzipsfx.wasm): http://infozip.sourceforge.net/UnZip.html
+- [ufetch](https://gitlab.com/kebo/ufetch)
 
 
 ## Commands already included in a-Shell (with their source code):

--- a/list
+++ b/list
@@ -54,6 +54,7 @@ texlive
 texlive-2025
 texlive_fonts
 texlive_fonts-2025
+ufetch
 unexpand
 which
 xmlcatalog

--- a/packages/ufetch
+++ b/packages/ufetch
@@ -1,0 +1,11 @@
+#!/bin/sh
+# install file for ufetch:
+
+packagename=${0##*/}
+
+# download command:
+curl -L https://gitlab.com/kebo/ufetch/-/raw/v0.4-ashell/ufetch-ashell -o ~/Documents/bin/"$packagename" --create-dirs --silent
+chmod +x ~/Documents/bin/"$packagename"
+
+# download uninstall information:
+curl -L https://raw.githubusercontent.com/holzschu/a-Shell-commands/master/uninstall/"$packagename" -o ~/Documents/.pkg/"$packagename" --create-dirs --silent

--- a/uninstall/ufetch
+++ b/uninstall/ufetch
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+packagename=${0##*/}
+
+# remove command
+rm ~/Documents/bin/"$packagename"


### PR DESCRIPTION
## Motivation

ufetch is a lightweight alternative to neofetch. It doesn't depend on bash, so it can also be executed with a-Shell's dash.

I made some changes to ufetch-macos to enable full support for a-Shell.

- The official repo: https://gitlab.com/jschx/ufetch
- ufetch for a-Shell: https://gitlab.com/kebo/ufetch/-/blob/a-shell/ufetch-ashell

![](https://files.mastodon.social/media_attachments/files/114/399/668/322/405/472/original/ae4a3cec7140a40b.png)

## Changes

I added scripts for installing and uninstalling ufetch.[^1]

[^1]: Reference: https://bianshen00009.gitbook.io/a-guide-to-a-shell/lets-do-more-for-it/submit-new-packages

## Test

Installing:

```console
$ ufetch
ufetch: command not found
$ PKG_SERVER=https://raw.githubusercontent.com/kkebo/a-Shell-commands/ufetch/ pkg install ufetch
Downloading ufetch
Done
$ ufetch
          _
         (/     mobile@localhost
    .---__--.   OS:        iPhone OS 19.0
   /         \  KERNEL:    Darwin 25.0.0
  |         /   UPTIME:    23:47
  |         \_  PACKAGES:  13
   \         /  SHELL:     sh
    `._.-._.`   DE:        SpringBoard

```

Uninstalling (`.pkg/ufetch` is 404 because this PR is not yet merged, so I replaced it with the correct script manually):

```console
$ cat .pkg/ufetch
404: Not Found
$ cp ~Repositories/a-Shell-commands/uninstall/ufetch .pkg/ufetch
$ ufetch
          _
         (/     mobile@localhost
    .---__--.   OS:        iPhone OS 19.0
   /         \  KERNEL:    Darwin 25.0.0
  |         /   UPTIME:    23:47
  |         \_  PACKAGES:  13
   \         /  SHELL:     sh
    `._.-._.`   DE:        SpringBoard

$ pkg uninstall ufetch
Removing ufetch
Done
$ ufetch
ufetch: command not found
```