### PR TITLE
Add qjs

### DIFF
--- a/list
+++ b/list
@@ -44,6 +44,7 @@ nnn
 oathtool
 paste
 printf
+qjs
 rg
 rs
 scheme-s7

--- a/packages/qjs
+++ b/packages/qjs
@@ -1,0 +1,9 @@
+#!/bin/sh
+# install script for qjs
+
+packagename=${0##*/}
+
+# download command:
+curl -L https://github.com/HeavySnowJakarta/a-Shell-commands/releases/download/quickjs-v0.10.1/qjs -o ~/Documents/bin/$packagename --create-dirs --silent
+# download uninstall information:
+curl -L https://raw.githubusercontent.com/holzschu/a-Shell-commands/master/uninstall/$packagename -o ~/Documents/.pkg/$packagename --create-dirs --silent

--- a/uninstall/qjs
+++ b/uninstall/qjs
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+# Default uninstall file for packages:
+packagename=${0##*/}
+
+# remove command
+rm ~/Documents/bin/$packagename


### PR DESCRIPTION
adds quickjs.

notes qjsc is also available at [the release](https://github.com/HeavySnowJakarta/a-Shell-commands/releases/tag/quickjs-v0.10.1), but i'm not certain about how it works well with a-shell. further researches may be required.