### PR TITLE
Fix for cut not found installing jupyter

### DIFF
--- a/packages/jupyter
+++ b/packages/jupyter
@@ -6,9 +6,10 @@ then
 	exit 0
 fi
 
-major=`echo $APPVERSION | cut -d. -f1`
-minor=`echo $APPVERSION | cut -d. -f2`
-revision=`echo $APPVERSION | cut -d. -f3`
+major=${APPVERSION%%.*}
+rest=${APPVERSION#*.}
+minor=${rest%%.*}
+revision=${rest#*.}
 
 if [ $major -eq 1 ]
 then


### PR DESCRIPTION
## Problem

On a clean a-Shell environment (or one without the `cut` package installed), running `pkg install jupyter` fails with the error:
```sh
$ pkg install jupyter
Downloading jupyter
/private/var/mobile/Containers/Data/Application/96C...DCC/tmp/jupyter: 1: cut: not found
```

## Cause

The script uses the external `cut` command to parse the `$APPVERSION` variable for its version check. Since `cut` is not a built-in command in a-Shell, this creates a dependency that was not declared, causing the script to fail if `cut` is not present.

The original version checking logic:
```bash
major=`echo $APPVERSION | cut -d. -f1`
minor=`echo $APPVERSION | cut -d. -f2`
revision=`echo $APPVERSION | cut -d. -f3`
```

## Solution

This change refactors the version-checking logic to use shell parameter expansion instead of `cut`. This method relies only on shell built-in features, removing the external dependency.

The new version checking logic:
```bash
major=${APPVERSION%%.*}
rest=${APPVERSION#*.}
minor=${rest%%.*}
revision=${rest#*.}
```