### PR TITLE
Update swift-format to 602.0.0

### DIFF
--- a/packages/swift-format
+++ b/packages/swift-format
@@ -2,7 +2,7 @@
 # install file for swift-format:
 
 packagename=${0##*/}
-packageversion=601.0.0
+packageversion=602.0.0
 
 # download command:
 curl -L https://github.com/kkebo/swift-format/releases/download/$packageversion-wasm32-wasi/swift-format.wasm -o ~/Documents/bin/"$packagename".wasm3 --create-dirs --silent


### PR DESCRIPTION
I've just released swift-format.wasm 602.0.0, following the upstream's [602.0.0 release](https://github.com/swiftlang/swift-format/releases/tag/602.0.0).

https://github.com/kkebo/swift-format/releases/tag/602.0.0-wasm32-wasi

Therefore, I would like to update the package so that a-Shell users can also use the latest version.